### PR TITLE
Parametrize ProvingSystem and ProofRecord

### DIFF
--- a/Anoma/Proving/System.juvix
+++ b/Anoma/Proving/System.juvix
@@ -1,20 +1,57 @@
 module Anoma.Proving.System;
 
 import Stdlib.Prelude open using {Bool};
-import Anoma.Proving.Types open using {ProvingKey; Proof; ProofRecord};
+import Anoma.Proving.Types open using {ProofRecord};
 import Anoma.Resource.Index as Resource open using {Instance; Witness};
 
 --- The interface of the resource machine proving system.
+--- Proof : A fixed-size data type encoding a proof.
+--- VerifyingKey : A fixed-size data type encoding a verifying key containing the data.
+--- ProvingKey : A fixed-size data type encoding a proving key containing the data.
+--- Witness : The subset of inputs used to produce but not verify a proof.
+--- Instance : The subset of inputs required to both create and verify a proof.
 trait
-type ProvingSystem :=
+type ProvingSystem Proof VerifyingKey ProvingKey Witness Instance :=
   mkProvingSystem {
-    --- Creates a ;Proof; given a ;ProvingKey;, public inputs (;Resource.Instance;), and
-    --- private inputs (;Resource.Witness;).
+    --- Creates a Proof given a ProvingKey, public inputs (Instance), and
+    --- private inputs (Witness).
     prove : (provingKey : ProvingKey)
-      -> (publicInputs : Resource.Instance)
-      -> (privateInputs : Resource.Witness)
+      -> (publicInputs : Instance)
+      -> (privateInputs : Witness)
       -> Proof;
 
     --- Verfies a ;ProofRecord;.
-    verify : (proofRecord : ProofRecord) -> Bool
+    verify : (proofRecord : ProofRecord Proof VerifyingKey Witness) -> Bool
   };
+
+--- An instantiation of a Proving System for Delta proofs.
+module Delta;
+  import Anoma.Proving.Types as T;
+
+  axiom Proof : Type;
+
+  axiom VerifyingKey : Type;
+
+  axiom ProvingKey : Type;
+
+  axiom Witness : Type;
+
+  axiom Instance : Type;
+
+  ProofRecord : Type := T.ProofRecord Proof VerifyingKey Witness;
+
+  axiom prove : (provingKey : ProvingKey)
+    -> (publicInputs : Instance)
+    -> (privateInputs : Witness)
+    -> Proof;
+
+  axiom verify : (proofRecord : ProofRecord) -> Bool;
+
+  instance
+  DeltaProvingSystem : ProvingSystem Proof VerifyingKey ProvingKey Witness Instance :=
+    mkProvingSystem@{
+      prove;
+      verify
+    };
+
+end;

--- a/Anoma/Proving/Types.juvix
+++ b/Anoma/Proving/Types.juvix
@@ -3,22 +3,24 @@ module Anoma.Proving.Types;
 import Stdlib.Prelude open using {Pair};
 import Anoma.Resource.Index as Resource open using {Witness};
 
---- A fixed-size data type encoding a proof.
-axiom Proof : Type;
-
---- A fixed-size data type encoding a verifying key containing the data,
---- along with a ;Resource.Witness;, to verify a proof.
-axiom VerifyingKey : Type;
-
---- A fixed-size data type encoding a proving key containing the data,
---- along with a ;Resource.Instance; and ;Resource.Witness;, to produce a proof.
-axiom ProvingKey : Type;
-
---- A record describing a proof record, a map entry constituted by a ;VerifyingKey; as the lookup-key
---- and a ;Proof; and associated ;Resource.Witness; as the value.
-ProofRecord : Type := Pair VerifyingKey (Pair Proof Resource.Witness);
+--- A record describing a proof record, a map entry constituted by a VerifyingKey as the lookup-key
+--- and a Proof and associated Witness as the value.
+ProofRecord (Proof VerifyingKey Witness : Type) : Type := Pair VerifyingKey (Pair Proof Resource.Witness);
 
 module DeltaProof;
   --- Aggregates two delta ;ProofRecord;s.
-  axiom aggregate : (p1 p2 : ProofRecord) -> ProofRecord;
+  axiom aggregate : (Proof VerifyingKey Witness : Type) -> (p1 p2 : ProofRecord Proof VerifyingKey Witness) -> ProofRecord Proof VerifyingKey Witness;
+end;
+
+--- A set of ProofRecords.
+---
+--- Each ProofRecord in the set may be parameterized with different types for
+--- Proof, VerifyingKey and Witness, allowing for heterogeneous ProofRecords
+--- within the set. It's not currently possible to represent such a set in Juvix.
+axiom ProofRecordSet : Type;
+
+module ProofRecordSet;
+
+  axiom empty : ProofRecordSet;
+
 end;

--- a/Anoma/Transaction/Action.juvix
+++ b/Anoma/Transaction/Action.juvix
@@ -4,7 +4,7 @@ import Stdlib.Prelude open using {Pair; Eq; Ord; Ordering; mkOrd};
 import Stdlib.Trait.Ord.Eq open using {fromOrdToEq};
 import Data.Set as Set open using {Set; union};
 import Anoma.Resource.Index as Resource open using {Resource};
-import Anoma.Proving.Types open using {ProofRecord};
+import Anoma.Proving.Types open using {ProofRecord; ProofRecordSet; module ProofRecordSet};
 
 module AppDataInternal;
   --- A fixed-size data type encoding the lookup key of application data being part of an action.
@@ -57,7 +57,7 @@ type Action :=
   mkAction {
     commitments : Set Resource.Commitment;
     nullifiers : Set Resource.Nullifier;
-    proofs : Set ProofRecord;
+    proofs : ProofRecordSet;
     appData : AppData
   };
 
@@ -80,7 +80,7 @@ compose (a1 a2 : Action) : Action :=
         s2 := Action.appData a2
       };
     -- TODO Proofs must be recomputed. Should this happen as part of `compose`?
-    proofs := Set.empty
+    proofs := ProofRecordSet.empty
   };
 
 module ActionInternal;

--- a/Anoma/Transaction/Types.juvix
+++ b/Anoma/Transaction/Types.juvix
@@ -9,6 +9,7 @@ import Anoma.Transaction.Action as Action open;
 import Anoma.Delta as Delta open using {Delta};
 import Anoma.MathProperty open;
 import Anoma.Proving.Types open;
+import Anoma.Proving.System open;
 
 --- A record describing a transaction object, the entity constituting a state transition in Anoma.
 positive
@@ -17,7 +18,7 @@ type Transaction :=
     roots : Set CommitmentTree.Root;
     actions : Set Action;
     delta : Delta;
-    deltaProof : ProofRecord
+    deltaProof : Delta.ProofRecord;
   };
 
 --- The ;Transaction; object constructor signature.
@@ -25,7 +26,7 @@ Constructor : Type :=
   (roots : Set CommitmentTree.Root)
     -> (actions : Set Action)
     -> (delta : Delta)
-    -> (deltaProof : ProofRecord)
+    -> (deltaProof : Delta.ProofRecord)
     -> Transaction;
 
 --- Compses two ;Transaction; objects.
@@ -49,6 +50,9 @@ compose (tx1 tx2 : Transaction) : Transaction :=
     -- };
     deltaProof :=
       DeltaProof.aggregate@{
+        Witness := Delta.Witness;
+        Proof := Delta.Proof;
+        VerifyingKey := Delta.VerifyingKey;
         p1 := Transaction.deltaProof tx1;
         p2 := Transaction.deltaProof tx2
       }


### PR DESCRIPTION
This allows several different ProvingSystems to be defined and used in the specification.