### PR TITLE
feat: add commitment tree and nullifier set instances

### DIFF
--- a/Anoma/State/CommitmentTree.juvix
+++ b/Anoma/State/CommitmentTree.juvix
@@ -32,6 +32,16 @@ type CommitmentTree :=
     root : (commitment : CommitmentTree) -> Root
   };
 
+--- The ;CommitmentTree; instantiation.
+instance
+Concrete-CommitmentTree : CommitmentTree :=
+  mkCommitmentTree@{
+    add := MISSING_ANOMA_BUILTIN;
+    path := MISSING_ANOMA_BUILTIN;
+    verify := MISSING_ANOMA_BUILTIN;
+    root := MISSING_ANOMA_BUILTIN
+  };
+
 module RootInternal;
   --- Compares two ;Root;s and returns their ;Ordering;.
   compare (lhs rhs : Root) : Ordering := Ord.cmp (Root.unRoot lhs) (Root.unRoot rhs);

--- a/Anoma/State/NullifierSet.juvix
+++ b/Anoma/State/NullifierSet.juvix
@@ -4,6 +4,7 @@ module Anoma.State.NullifierSet;
 
 import Stdlib.Prelude open;
 import Anoma.Resource.Types as Resource open using {Nullifier};
+import Anoma.Utils open;
 
 --- The interface of the nullifier set.
 trait
@@ -15,4 +16,12 @@ type NullifierSet :=
 
     --- Checks if a ;Resource.Nullifier; exists in the ;NullifierSet;.
     exists : (nullifier : Resource.Nullifier) -> Bool
+  };
+
+--- The ;NullifierSet; instantiation.
+instance
+Concrete-NullifierSet : NullifierSet :=
+  mkNullifierSet@{
+    add := MISSING_ANOMA_BUILTIN;
+    exists := MISSING_ANOMA_BUILTIN
   };


### PR DESCRIPTION
The commitment tree instance, for example, is needed to populate the `roots` field of the transaction object.