### PR TITLE
fix: wrong proof record definition

### DIFF
--- a/Anoma/Proving/ComplianceProof.juvix
+++ b/Anoma/Proving/ComplianceProof.juvix
@@ -6,7 +6,7 @@ import Anoma.Proving.Types as Parametrized open using {module Compliance};
 import Anoma.Utils open;
 
 ProofRecord : Type :=
-  Parametrized.GenericProofRecord Compliance.Proof Compliance.VerifyingKey Compliance.Witness;
+  Parametrized.GenericProofRecord Compliance.Proof Compliance.VerifyingKey Compliance.Instance;
 
 prove
   (provingKey : Compliance.ProvingKey)

--- a/Anoma/Proving/DeltaProof.juvix
+++ b/Anoma/Proving/DeltaProof.juvix
@@ -5,7 +5,7 @@ import Stdlib.Prelude open;
 import Anoma.Proving.Types as Parametrized open using {module Delta};
 import Anoma.Utils open;
 
-ProofRecord : Type := Parametrized.GenericProofRecord Delta.Proof Delta.VerifyingKey Delta.Witness;
+ProofRecord : Type := Parametrized.GenericProofRecord Delta.Proof Delta.VerifyingKey Delta.Instance;
 
 prove
   (provingKey : Delta.ProvingKey)

--- a/Anoma/Proving/ProofRecord.juvix
+++ b/Anoma/Proving/ProofRecord.juvix
@@ -16,7 +16,7 @@ type ProofRecord :=
 module ProofRecordInternal;
   instance
   ProofRecord-Ord : Ord ProofRecord :=
-    -- lexicographical ordering with proofRecordCompliance _ < proofRecordResourceLogic _ < proofRecordDelta _
+    -- lexicographical ordering with `proofRecordCompliance _ < proofRecordResourceLogic _ < proofRecordDelta _`.
     mkOrd@{
       cmp (p1 p2 : ProofRecord) : Ordering :=
         case p1, p2 of

--- a/Anoma/Proving/ResourceLogicProof.juvix
+++ b/Anoma/Proving/ResourceLogicProof.juvix
@@ -9,7 +9,7 @@ ProofRecord : Type :=
   Parametrized.GenericProofRecord
     ResourceLogic.Proof
     ResourceLogic.VerifyingKey
-    ResourceLogic.Witness;
+    ResourceLogic.Instance;
 
 prove
   (provingKey : ResourceLogic.ProvingKey)

--- a/Anoma/Proving/Types.juvix
+++ b/Anoma/Proving/Types.juvix
@@ -5,6 +5,8 @@ import Stdlib.Trait.Ord.Eq open using {fromOrdToEq};
 import Data.Set as Set open using {Set};
 import Anoma.Resource.Object open using {Resource};
 import Anoma.Resource.Types open using {Commitment; Nullifier};
+import Anoma.Resource.Computable.Commitment open using {module CommitmentInternal};
+import Anoma.Resource.Computable.Nullifier open using {module NullfierInternal};
 import Anoma.Transaction.AppData open using {AppData};
 import Anoma.Utils open;
 
@@ -60,7 +62,7 @@ module Delta;
     instance
     Instance-Ord : Ord Instance := mkOrd compare;
 
-    --- Implements the ;Eq; trait for ;Witness;.
+    --- Implements the ;Eq; trait for ;Instance;.
     instance
     Instance-Eq : Eq Instance := fromOrdToEq;
   end;
@@ -114,6 +116,25 @@ module ResourceLogic;
       custom : CustomInputs
     };
 
+  module TagInternal;
+    --- Compares two ;CustomInputs; objects.
+    --- Lexicographical ordering with `Created _ < Consumed _`.
+    compare (lhs rhs : Tag) : Ordering :=
+      case lhs, rhs of
+        | Created cmLhs, Created cmRhs := Ord.cmp cmLhs cmRhs
+        | Consumed nfLhs, Consumed nfRhs := Ord.cmp nfLhs nfRhs
+        | Created _, Consumed _ := LT
+        | Consumed _, Created _ := GT;
+
+    --- Implements the ;Ord; trait for ;Tag;.
+    instance
+    Tag-Ord : Ord Tag := mkOrd compare;
+
+    --- Implements the ;Eq; trait for ;Tag;.
+    instance
+    Tag-Eq : Eq Tag := fromOrdToEq;
+  end;
+
   module CustomInputsInternal;
     --- Compares two ;CustomInputs; objects.
     compare (lhs rhs : CustomInputs) : Ordering :=
@@ -153,6 +174,23 @@ module ResourceLogic;
     --- Implements the ;Eq; trait for ;VerifyingKey;.
     instance
     VerifyingKey-Eq : Eq VerifyingKey := fromOrdToEq;
+  end;
+
+  module InstanceInternal;
+    --- Compares two ;Instance; objects.
+    compare (lhs rhs : Instance) : Ordering :=
+      let
+        prod (i : Instance) : _ :=
+          Instance.tag i, Instance.commitments i, Instance.nullifiers i, Instance.appData i;
+      in Ord.cmp (prod lhs) (prod rhs);
+
+    --- Implements the ;Ord; trait for ;Instance;.
+    instance
+    Instance-Ord : Ord Instance := mkOrd compare;
+
+    --- Implements the ;Eq; trait for ;Instance;.
+    instance
+    Instance-Eq : Eq Instance := fromOrdToEq;
   end;
 
   module WitnessInternal;
@@ -208,6 +246,20 @@ module Compliance;
     --- Implements the ;Eq; trait for ;VerifyingKey;.
     instance
     VerifyingKey-Eq : Eq VerifyingKey := fromOrdToEq;
+  end;
+
+  module InstanceInternal;
+    --- Compares two ;Instance; objects.
+    compare (lhs rhs : Instance) : Ordering :=
+      Ord.cmp (Instance.unInstance lhs) (Instance.unInstance rhs);
+
+    --- Implements the ;Ord; trait for ;Instance;.
+    instance
+    Instance-Ord : Ord Instance := mkOrd compare;
+
+    --- Implements the ;Eq; trait for ;Instance;.
+    instance
+    Instance-Eq : Eq Instance := fromOrdToEq;
   end;
 
   module WitnessInternal;

--- a/Anoma/Proving/Types.juvix
+++ b/Anoma/Proving/Types.juvix
@@ -9,9 +9,9 @@ import Anoma.Transaction.AppData open using {AppData};
 import Anoma.Utils open;
 
 --- A record describing a proof record, a map entry constituted by a VerifyingKey as the lookup-key
---- and a Proof and associated Witness as the value.
-GenericProofRecord (Proof VerifyingKey Witness : Type) : Type :=
-  Pair VerifyingKey (Pair Proof Witness);
+--- and a Proof and associated instance as the value.
+GenericProofRecord (Proof VerifyingKey Instance : Type) : Type :=
+  Pair VerifyingKey (Pair Proof Instance);
 
 module Delta;
   type Proof := mkProof {unProof : MISSING_DEFINITION};
@@ -49,6 +49,20 @@ module Delta;
     --- Implements the ;Eq; trait for ;VerifyingKey;.
     instance
     VerifyingKey-Eq : Eq VerifyingKey := fromOrdToEq;
+  end;
+
+  module InstanceInternal;
+    --- Compares two ;Instance; objects.
+    compare (lhs rhs : Instance) : Ordering :=
+      Ord.cmp (Instance.unInstance lhs) (Instance.unInstance rhs);
+
+    --- Implements the ;Ord; trait for ;Instance;.
+    instance
+    Instance-Ord : Ord Instance := mkOrd compare;
+
+    --- Implements the ;Eq; trait for ;Witness;.
+    instance
+    Instance-Eq : Eq Instance := fromOrdToEq;
   end;
 
   module WitnessInternal;


### PR DESCRIPTION
The definition of `ProofRecord` was wrong and contained the `Witness` instead of the `Instance` (compare with the specs https://specs.anoma.net/v2/basic_abstractions/proving/proof.html).

```diff
- GenericProofRecord (Proof VerifyingKey Witness : Type) : Type := Pair VerifyingKey (Pair Proof Witness);
+ GenericProofRecord (Proof VerifyingKey Instance : Type) : Type := Pair VerifyingKey (Pair Proof Instance);  
```

This PR fixes this.