### PR TITLE
fix: replace generic proof record type

### DIFF
--- a/Anoma/Proving/ComplianceProof.juvix
+++ b/Anoma/Proving/ComplianceProof.juvix
@@ -2,11 +2,16 @@
 module Anoma.Proving.ComplianceProof;
 
 import Stdlib.Prelude open;
-import Anoma.Proving.Types as Parametrized open using {module Compliance};
+import Stdlib.Trait.Ord.Eq open using {fromOrdToEq};
+import Anoma.Proving.Types open using {module Compliance};
 import Anoma.Utils open;
 
-ProofRecord : Type :=
-  Parametrized.GenericProofRecord Compliance.Proof Compliance.VerifyingKey Compliance.Instance;
+type ProofRecord :=
+  mkProofRecord {
+    proof : Compliance.Proof;
+    verifyingKey : Compliance.VerifyingKey;
+    instance : Compliance.Instance
+  };
 
 prove
   (provingKey : Compliance.ProvingKey)
@@ -15,3 +20,20 @@ prove
   : Compliance.Proof := MISSING_ANOMA_BUILTIN;
 
 verify (proofRecord : ProofRecord) : Bool := MISSING_ANOMA_BUILTIN;
+
+module ProofRecordInternal;
+  --- Compares two ;ProofRecord; objects.
+  compare (lhs rhs : ProofRecord) : Ordering :=
+    let
+      prod (p : ProofRecord) : _ :=
+        ProofRecord.proof p, ProofRecord.verifyingKey p, ProofRecord.instance p;
+    in Ord.cmp (prod lhs) (prod rhs);
+
+  --- Implements the ;Ord; trait for ;ProofRecord;.
+  instance
+  ProofRecord-Ord : Ord ProofRecord := mkOrd compare;
+
+  --- Implements the ;Eq; trait for ;ProofRecord;.
+  instance
+  ProofRecord-Eq : Eq ProofRecord := fromOrdToEq;
+end;

--- a/Anoma/Proving/DeltaProof.juvix
+++ b/Anoma/Proving/DeltaProof.juvix
@@ -2,10 +2,16 @@
 module Anoma.Proving.DeltaProof;
 
 import Stdlib.Prelude open;
-import Anoma.Proving.Types as Parametrized open using {module Delta};
+import Stdlib.Trait.Ord.Eq open using {fromOrdToEq};
+import Anoma.Proving.Types open using {module Delta};
 import Anoma.Utils open;
 
-ProofRecord : Type := Parametrized.GenericProofRecord Delta.Proof Delta.VerifyingKey Delta.Instance;
+type ProofRecord :=
+  mkProofRecord {
+    proof : Delta.Proof;
+    verifyingKey : Delta.VerifyingKey;
+    instance : Delta.Instance
+  };
 
 prove
   (provingKey : Delta.ProvingKey)
@@ -17,3 +23,20 @@ verify (proofRecord : ProofRecord) : Bool := MISSING_ANOMA_BUILTIN;
 
 --- Aggregates two  delta ;ProofRecord;s.
 aggregate (p1 p2 : ProofRecord) : ProofRecord := ANOMA_BACKEND_IMPLEMENTATION;
+
+module ProofRecordInternal;
+  --- Compares two ;ProofRecord; objects.
+  compare (lhs rhs : ProofRecord) : Ordering :=
+    let
+      prod (p : ProofRecord) : _ :=
+        ProofRecord.proof p, ProofRecord.verifyingKey p, ProofRecord.instance p;
+    in Ord.cmp (prod lhs) (prod rhs);
+
+  --- Implements the ;Ord; trait for ;ProofRecord;.
+  instance
+  ProofRecord-Ord : Ord ProofRecord := mkOrd compare;
+
+  --- Implements the ;Eq; trait for ;ProofRecord;.
+  instance
+  ProofRecord-Eq : Eq ProofRecord := fromOrdToEq;
+end;

--- a/Anoma/Proving/LogicProof.juvix
+++ b/Anoma/Proving/LogicProof.juvix
@@ -2,14 +2,16 @@
 module Anoma.Proving.LogicProof;
 
 import Stdlib.Prelude open;
-import Anoma.Proving.Types as Parametrized open using {module Logic};
+import Stdlib.Trait.Ord.Eq open using {fromOrdToEq};
+import Anoma.Proving.Types open using {module Logic};
 import Anoma.Utils open;
 
-ProofRecord : Type :=
-  Parametrized.GenericProofRecord
-    Logic.Proof
-    Logic.VerifyingKey
-    Logic.Instance;
+type ProofRecord :=
+  mkProofRecord {
+    proof : Logic.Proof;
+    verifyingKey : Logic.VerifyingKey;
+    instance : Logic.Instance
+  };
 
 prove
   (provingKey : Logic.ProvingKey)
@@ -18,3 +20,20 @@ prove
   : Logic.Proof := MISSING_ANOMA_BUILTIN;
 
 verify (proofRecord : ProofRecord) : Bool := MISSING_ANOMA_BUILTIN;
+
+module ProofRecordInternal;
+  --- Compares two ;ProofRecord; objects.
+  compare (lhs rhs : ProofRecord) : Ordering :=
+    let
+      prod (p : ProofRecord) : _ :=
+        ProofRecord.proof p, ProofRecord.verifyingKey p, ProofRecord.instance p;
+    in Ord.cmp (prod lhs) (prod rhs);
+
+  --- Implements the ;Ord; trait for ;ProofRecord;.
+  instance
+  ProofRecord-Ord : Ord ProofRecord := mkOrd compare;
+
+  --- Implements the ;Eq; trait for ;ProofRecord;.
+  instance
+  ProofRecord-Eq : Eq ProofRecord := fromOrdToEq;
+end;

--- a/Anoma/Proving/Types.juvix
+++ b/Anoma/Proving/Types.juvix
@@ -10,11 +10,6 @@ import Anoma.Resource.Computable.Nullifier open using {module NullfierInternal};
 import Anoma.Transaction.AppData open using {AppData};
 import Anoma.Utils open;
 
---- A record describing a proof record, a map entry constituted by a VerifyingKey as the lookup-key
---- and a Proof and associated instance as the value.
-GenericProofRecord (Proof VerifyingKey Instance : Type) : Type :=
-  Pair VerifyingKey (Pair Proof Instance);
-
 module Delta;
   type Proof := mkProof {unProof : MISSING_DEFINITION};
 

--- a/Anoma/State/ResourceMachine.juvix
+++ b/Anoma/State/ResourceMachine.juvix
@@ -6,7 +6,7 @@ import Anoma.Transaction.Object as Transaction open using {Transaction; mkTransa
 import Anoma.State.CommitmentTree as CommitmentTree open using {Root};
 import Anoma.Transaction.Action as Action open using {Action};
 import Anoma.Delta as Delta open using {Delta};
-import Anoma.Proving.DeltaProof as DeltaProof;
+import Anoma.Proving.ProofRecord open using {ProofRecord};
 
 --- The resource machine interface.
 trait
@@ -16,7 +16,7 @@ type ResourceMachine :=
     create : (roots : Set CommitmentTree.Root)
       -> (actions : Set Action)
       -> (delta : Delta)
-      -> (deltaProof : DeltaProof.ProofRecord)
+      -> (deltaProof : ProofRecord)
       -> Transaction;
 
     --- Composes two ;Transaction;s with the transa

--- a/Anoma/Transaction/Object.juvix
+++ b/Anoma/Transaction/Object.juvix
@@ -6,7 +6,7 @@ import Anoma.Resource.Types as Resource;
 import Anoma.State.CommitmentTree as CommitmentTree;
 import Anoma.Transaction.Action open using {Action};
 import Anoma.Delta as Delta open using {Delta};
-import Anoma.Proving.DeltaProof as DeltaProof;
+import Anoma.Proving.ProofRecord open using {ProofRecord};
 import Anoma.Utils open;
 
 --- A record describing a transaction object, the entity constituting a state transition in Anoma.
@@ -16,7 +16,7 @@ type Transaction :=
     roots : Set CommitmentTree.Root;
     actions : Set Action;
     delta : Delta;
-    deltaProofRecord : DeltaProof.ProofRecord
+    deltaProofRecord : ProofRecord
   };
 
 --- Composes two ;Transaction; objects.


### PR DESCRIPTION
@paulcadman can you review and see if this makes sense? Should we use the generic proof record type here as we are doing it already within the `Action` record?

https://github.com/anoma/juvix-arm-specs/blob/311f737f007e938b1b34c6cb2c738f0be9f41c5c/Anoma/Transaction/Action.juvix#L17-L23