### PR TITLE
feat: implement `composeTransactions` in Juvix

### DIFF
--- a/Anoma/Delta/ProvingSystem.juvix
+++ b/Anoma/Delta/ProvingSystem.juvix
@@ -13,5 +13,5 @@ prove
 
 verify (proofRecord : ProofRecord) : Bool := MISSING_ANOMA_BUILTIN;
 
---- Aggregates two  delta ;ProofRecord;s.
+--- Aggregates two delta ;ProofRecord;s.
 aggregate (p1 p2 : ProofRecord) : ProofRecord := ANOMA_BACKEND_IMPLEMENTATION;

--- a/Anoma/Logic/ProvingSystem.juvix
+++ b/Anoma/Logic/ProvingSystem.juvix
@@ -12,6 +12,3 @@ prove
   : Proof := MISSING_ANOMA_BUILTIN;
 
 verify (proofRecord : ProofRecord) : Bool := MISSING_ANOMA_BUILTIN;
-
---- Aggregates two  delta ;ProofRecord;s.
-aggregate (p1 p2 : ProofRecord) : ProofRecord := ANOMA_BACKEND_IMPLEMENTATION;

--- a/Anoma/State/ResourceMachine.juvix
+++ b/Anoma/State/ResourceMachine.juvix
@@ -11,7 +11,6 @@ import Anoma.Transaction.Object as Transaction open using {
 import Anoma.State.CommitmentTree as CommitmentTree open using {Root};
 import Anoma.Transaction.Action as Action open using {Action};
 import Anoma.Delta as Delta open using {Delta};
-import Anoma.Generic.ProofRecord open using {ProofRecord};
 
 --- The resource machine interface.
 trait
@@ -21,7 +20,7 @@ type ResourceMachine :=
     create : (roots : Set CommitmentTree.Root)
       -> (actions : Set Action)
       -> (delta : Delta)
-      -> (deltaProof : ProofRecord)
+      -> (deltaProof : Delta.ProofRecord)
       -> Transaction;
 
     --- Composes two ;Transaction;s with the transa

--- a/Anoma/Transaction/Object.juvix
+++ b/Anoma/Transaction/Object.juvix
@@ -23,6 +23,7 @@ type Transaction :=
 --- Computes the ;Transaction; ;Delta;.
 transactionDelta (transaction : Transaction) : Delta := MISSING_ANOMA_BUILTIN;
 
+--- TODO Remove this placeholder.
 axiom dummy : {A : Type} -> A;
 
 --- Composes two ;Transaction; objects.
@@ -31,7 +32,7 @@ composeTransactions (tx1 tx2 : Transaction) : Transaction :=
     roots := Set.union (Transaction.roots tx1) (Transaction.roots tx2);
     actions := Set.union (Transaction.actions tx1) (Transaction.actions tx2);
     delta := Delta.addDelta (Transaction.delta tx1) (Transaction.delta tx2);
-    --- TODO Fix when inputs deltaProofRecord are known.
+    --- TODO This is WIP because the delta proof computation iss underspecified.
     deltaProofRecord :=
       DeltaProofRecord (Delta.mkProofRecord dummy dummy dummy);
   };

--- a/Anoma/Transaction/Object.juvix
+++ b/Anoma/Transaction/Object.juvix
@@ -7,7 +7,7 @@ import Anoma.Resource.Types as Resource;
 import Anoma.State.CommitmentTree as CommitmentTree;
 import Anoma.Transaction.Action open using {Action};
 import Anoma.Delta as Delta open using {Delta};
-import Anoma.Generic.ProofRecord open using {ProofRecord};
+import Anoma.Generic.ProofRecord open using {ProofRecord; DeltaProofRecord};
 import Anoma.Utils open;
 
 --- A record describing a transaction object, the entity constituting a state transition in Anoma.
@@ -23,9 +23,18 @@ type Transaction :=
 --- Computes the ;Transaction; ;Delta;.
 transactionDelta (transaction : Transaction) : Delta := MISSING_ANOMA_BUILTIN;
 
+axiom dummy : {A : Type} -> A;
+
 --- Composes two ;Transaction; objects.
 composeTransactions (tx1 tx2 : Transaction) : Transaction :=
-  MISSING_ANOMA_BUILTIN;
+  mkTransaction@{
+    roots := Set.union (Transaction.roots tx1) (Transaction.roots tx2);
+    actions := Set.union (Transaction.actions tx1) (Transaction.actions tx2);
+    delta := Delta.addDelta (Transaction.delta tx1) (Transaction.delta tx2);
+    --- TODO Fix when inputs deltaProofRecord are known.
+    deltaProofRecord :=
+      DeltaProofRecord (Delta.mkProofRecord dummy dummy dummy);
+  };
 
 --- Verifies a ;Transaction;.
 verifyTransaction (tx : Transaction) : Bool := MISSING_ANOMA_BUILTIN;

--- a/Anoma/Transaction/Object.juvix
+++ b/Anoma/Transaction/Object.juvix
@@ -7,7 +7,7 @@ import Anoma.Resource.Types as Resource;
 import Anoma.State.CommitmentTree as CommitmentTree;
 import Anoma.Transaction.Action open using {Action};
 import Anoma.Delta as Delta open using {Delta};
-import Anoma.Generic.ProofRecord open using {ProofRecord; DeltaProofRecord};
+import Anoma.Generic.ProofRecord open using {ProofRecord};
 import Anoma.Utils open;
 
 --- A record describing a transaction object, the entity constituting a state transition in Anoma.
@@ -17,14 +17,11 @@ type Transaction :=
     roots : Set CommitmentTree.Root;
     actions : Set Action;
     delta : Delta;
-    deltaProofRecord : ProofRecord;
+    deltaProofRecord : Delta.ProofRecord;
   };
 
 --- Computes the ;Transaction; ;Delta;.
 transactionDelta (transaction : Transaction) : Delta := MISSING_ANOMA_BUILTIN;
-
---- TODO Remove this placeholder.
-axiom dummy : {A : Type} -> A;
 
 --- Composes two ;Transaction; objects.
 composeTransactions (tx1 tx2 : Transaction) : Transaction :=
@@ -32,9 +29,10 @@ composeTransactions (tx1 tx2 : Transaction) : Transaction :=
     roots := Set.union (Transaction.roots tx1) (Transaction.roots tx2);
     actions := Set.union (Transaction.actions tx1) (Transaction.actions tx2);
     delta := Delta.addDelta (Transaction.delta tx1) (Transaction.delta tx2);
-    --- TODO This is WIP because the delta proof computation iss underspecified.
     deltaProofRecord :=
-      DeltaProofRecord (Delta.mkProofRecord dummy dummy dummy);
+      Delta.aggregate
+        (Transaction.deltaProofRecord tx1)
+        (Transaction.deltaProofRecord tx2);
   };
 
 --- Verifies a ;Transaction;.


### PR DESCRIPTION
This PR implements the `composeTransactions (tx1 tx2 : Transaction) : Transaction` function as raised in https://github.com/anoma/juvix-arm-specs/issues/21#issuecomment-2451691060.

> I see. For commitments and nullifiers, this makes sense to me, it's nice that the transparent RM could change implementation details without developers needing to change their programs. I think in that case implementing these functions as builtins in the Juvix Nock interpreter is sufficient. For transaction composition, I still don't think this makes sense, as the transaction data type is defined in Juvix anyways - it would never make sense for the transparent implementation to redefine what composition means. Do you think the boundary there makes sense?
