### PR TITLE
Add RM low-level interface and high-level to low-level translation

### DIFF
--- a/Anoma/Base.juvix
+++ b/Anoma/Base.juvix
@@ -23,6 +23,7 @@ https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/doc
 module Anoma.Base;
 
 import Stdlib.Prelude open;
+import Anoma.Base.Set as Set open using {Set};
 
 --- A module containing Nock types used in the interface.
 ---

--- a/Anoma/Base.juvix
+++ b/Anoma/Base.juvix
@@ -240,8 +240,8 @@ module Transaction;
   -- Add the Transaction projection functions to the scope for convenience.
   open Transaction public;
 
-  --- Compute the delta for a list of actions.
-  axiom actionsDelta : List Action -> Delta;
+  --- Compute the delta for a set of actions.
+  axiom actionsDelta : Set Action -> Delta;
 
   --- Compute a proof for the transaction balance.
   axiom proveBalance : Transaction -> Proof;

--- a/Anoma/Base.juvix
+++ b/Anoma/Base.juvix
@@ -24,19 +24,6 @@ module Anoma.Base;
 
 import Stdlib.Prelude open;
 
---- A module containing types that are currently unknown or require furhter discussion.
--- SPEC_QUESTION / INST_QUESTION: What should these types be?
-module Unknown;
-  -- This is currently equal to the function type in RM instantiation.
-  axiom ResourceLogicFieldType : Type;
-
-  -- This is currently Nock.Atom in the RM instantiation.
-  axiom ResourceLabelFieldType : Type;
-
-  -- This is currently Nock.ByteArray in the RM instantiation.
-  axiom ResourceValueFieldType : Type;
-end;
-
 --- A module containing Nock types used in the interface.
 ---
 --- Stanard Juvix types (e.g Bool and Nat) are used in the interface where the
@@ -87,54 +74,6 @@ end;
 -- Add opaque types to the scope for convenience.
 open Opaque public;
 
---- A module containing data types and functions related to resources.
---- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/resource/definition.md
-module Resource;
-
-  type Resource :=
-    mkResource@{
-      --- A 'succinct' representation of the resource logic.
-      logic : Unknown.ResourceLogicFieldType;
-      --- Specifies the fungibility domain for the resource.
-      label : Unknown.ResourceLabelFieldType;
-      --- A number representing the quentity of the resource.
-      quantity : Nat;
-      --- The fungible data associated with the resource.
-      value : Unknown.ResourceValueFieldType;
-      --- A flag that reflects the resource's ephemerality.
-      isEphemeral : Bool;
-      --- Guarantees the uniqueness of the resource computable components.
-      nonce : Nock.Atom;
-      --- Nullifier key commitment
-      nullifierKeyCommitment : Nock.Atom;
-      --- Randomness seed
-      rseed : Nock.Atom
-    };
-
-  -- Add the Resource projection functions into scope for convenience.
-  open Resource public;
-
-  --- Compute a commitment to a ;Resource;
-  --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/resource/computable_components/commitment.md?plain=1#L8
-  axiom commitment : Resource -> Commitment;
-
-  --- Compute the kind of a ;Resource;
-  --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/resource/computable_components/kind.md?plain=1#L9
-  axiom kind : Resource -> Kind;
-
-  --- Compute the nullifier of a ;Resource;
-  --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/resource/computable_components/nullifier.md?plain=1#L8
-  axiom nullifier : Resource -> Nullifier;
-
-  --- Compute the delta of a ;Resource;
-  --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/resource/computable_components/delta.md?plain=1#L8
-  axiom delta : Resource -> Delta;
-
-end;
-
--- Add the Resource type and constructor to the scope for convenience.
-open Resource using {Resource; mkResource} public;
-
 --- A module containing data types and functions related to actions.
 --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/action.md
 module Action;
@@ -182,10 +121,37 @@ end;
 -- Add the Action types and constructors to the scope for convenience.
 open Action using {Action; mkAction; AppDataElement; module AppDataElement; mkAppDataElement; AppDataValue; module AppDataValue; mkAppDataValue} public;
 
---- A module containing types related to the resource logic.
---- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/function_formats/resource_logic.md?plain=1#L8
-module ResourceLogic;
+--- A module containing data types and functions related to resources.
+--- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/resource/definition.md
+module Resource;
 
+  -- SPEC_QUESTION: Is this a valid signature for a resource logic function?
+  ResourceLogic : Type := PublicInputs -> PrivateInputs -> Bool;
+
+  positive
+  type Resource :=
+    mkResource@{
+      --- A 'succinct' representation of the resource logic.
+      logic : ResourceLogic;
+      --- Specifies the fungibility domain for the resource.
+      label : Nock.Atom;
+      --- A number representing the quentity of the resource.
+      quantity : Nat;
+      --- The fungible data associated with the resource.
+      value : Nock.ByteArray;
+      --- A flag that reflects the resource's ephemerality.
+      isEphemeral : Bool;
+      --- Guarantees the uniqueness of the resource computable components.
+      nonce : Nock.Atom;
+      --- Nullifier key commitment
+      nullifierKeyCommitment : Nock.Atom;
+      --- Randomness seed
+      rseed : Nock.Atom
+    };
+
+  --- Types related to the resource logic
+  --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/function_formats/resource_logic.md?plain=1#L8
+  positive
   type PublicInputs :=
     mkPublicInputs@{
       commitments : Set Commitment;
@@ -198,6 +164,7 @@ module ResourceLogic;
       appData : Set AppDataElement
     };
 
+  positive
   type PrivateInputs :=
     mkPrivateInputs@{
       created : Set Resource;
@@ -207,19 +174,34 @@ module ResourceLogic;
       customInputs : Nock.Atom
     };
 
-  --- The type of a resource logic.
-  -- SPEC_QUESTION: Is this a valid signature for a resource logic function?
-  ResourceLogic : Type := PublicInputs -> PrivateInputs -> Bool;
-
   --- Compute a proof for a resource logic
   -- SPEC_QUESTION: Is this a valid signature for computing a proof of a
   -- transparent resource logic function?
   axiom prove : Resource -> PublicInputs -> PrivateInputs -> Proof;
 
+  -- Add the Resource projection functions into scope for convenience.
+  open Resource public;
+
+  --- Compute a commitment to a ;Resource;
+  --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/resource/computable_components/commitment.md?plain=1#L8
+  axiom commitment : Resource -> Commitment;
+
+  --- Compute the kind of a ;Resource;
+  --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/resource/computable_components/kind.md?plain=1#L9
+  axiom kind : Resource -> Kind;
+
+  --- Compute the nullifier of a ;Resource;
+  --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/resource/computable_components/nullifier.md?plain=1#L8
+  axiom nullifier : Resource -> Nullifier;
+
+  --- Compute the delta of a ;Resource;
+  --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/resource/computable_components/delta.md?plain=1#L8
+  axiom delta : Resource -> Delta;
+
 end;
 
--- Add the ResourceLogic, PublicInputs, and PrivateInputs types to the scope for convenience.
-open ResourceLogic using {ResourceLogic; PublicInputs; module PublicInputs; PrivateInputs; module PrivateInputs};
+-- Add the Resource type and constructor to the scope for convenience.
+open Resource using {Resource; mkResource; ResourceLogic; PublicInputs; module PublicInputs; mkPublicInputs; PrivateInputs; module PrivateInputs; mkPrivateInputs} public;
 
 --- A module containing data types and functions related to transactions.
 --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/transaction.md?plain=1#L8

--- a/Anoma/Base.juvix
+++ b/Anoma/Base.juvix
@@ -31,7 +31,7 @@ import Anoma.Base.Set as Set open using {Set};
 --- semantics of the Juvix type and the Nock type are the same (e.g a boolean flag).
 module Nock;
   --- A type representing a Nock atom.
-  type Atom := mkAtom Nat;
+  Atom : Type := Nat;
 
   --- The Nock encoding of a ByteArray.
   type ByteArray :=
@@ -39,7 +39,7 @@ module Nock;
       --- The number of bytes in the ByteArray.
       length : Atom;
       --- The bytes of the ByteArray represented as an ;Atom; in little-endian byte ordering.
-      payload : Atom
+      payload : Atom;
     };
 end;
 
@@ -79,13 +79,13 @@ module Action;
     mkAppDataValue@{
       value : Nock.Atom;
       -- SPEC_QUESTION: Is the deletion criterion required?
-      deletionCriterion : Nock.Atom
+      deletionCriterion : Nock.Atom;
     };
 
   type AppDataElement :=
     mkAppDataElement@{
       key : Nock.Atom;
-      value : AppDataValue
+      value : AppDataValue;
     };
 
   type Action :=
@@ -100,7 +100,7 @@ module Action;
       --- Application specific data needed to create resource logic proofs.
       -- SPEC_QUESTION, INST_QUESTION: The RM instantiation does not enforce
       -- this type, it accepts any data. Does this need to be specified?
-      appData : Set AppDataElement
+      appData : Set AppDataElement;
     };
 
   -- Add the Action and AppData projection functions to the scope for convenience.
@@ -116,34 +116,61 @@ module Action;
 end;
 
 -- Add the Action types and constructors to the scope for convenience.
-open Action using {Action; mkAction; AppDataElement; module AppDataElement; mkAppDataElement; AppDataValue; module AppDataValue; mkAppDataValue} public;
+open Action using {
+  Action;
+  mkAction;
+  AppDataElement;
+  module AppDataElement;
+  mkAppDataElement;
+  AppDataValue;
+  module AppDataValue;
+  mkAppDataValue;
+} public;
 
 --- A module containing data types and functions related to resources.
 --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/resource/definition.md
 module Resource;
 
   -- SPEC_QUESTION: Is this a valid signature for a resource logic function?
-  ResourceLogic : Type := PublicInputs -> PrivateInputs -> Bool;
+  Logic : Type := PublicInputs -> PrivateInputs -> Bool;
+
+  Label : Type := Nock.Atom;
+
+  Value : Type := Nock.ByteArray;
+
+  Quantity : Type := Nat;
+
+  NullifierKeyCommitment : Type := Nock.Atom;
+
+  Nonce : Type := Nock.Atom;
+
+  RSeed : Type := Nock.Atom;
 
   positive
   type Resource :=
     mkResource@{
       --- A 'succinct' representation of the resource logic.
-      logic : ResourceLogic;
+      logic : Logic;
       --- Specifies the fungibility domain for the resource.
-      label : Nock.Atom;
+      label : Label;
       --- A number representing the quentity of the resource.
-      quantity : Nat;
+      quantity : Quantity;
       --- The fungible data associated with the resource.
-      value : Nock.ByteArray;
+      value : Value;
       --- A flag that reflects the resource's ephemerality.
       isEphemeral : Bool;
       --- Guarantees the uniqueness of the resource computable components.
-      nonce : Nock.Atom;
-      --- Nullifier key commitment
-      nullifierKeyCommitment : Nock.Atom;
+      ---
+      --- NOTE: This should be a number having an at most negligible chance of
+      --- repeating is sufficient, e.g., a pseudo-random number.
+      nonce : Nonce;
+      --- The public commitment to the private nullifier key.
+      nullifierKeyCommitment : NullifierKeyCommitment;
       --- Randomness seed
-      rseed : Nock.Atom
+      ---
+      --- NOTE: This seed provides pseudo randomness and cannot be expected to
+      --- provide true randomness.
+      rseed : RSeed;
     };
 
   --- Types related to the resource logic
@@ -158,7 +185,7 @@ module Resource;
       tag : Nock.Atom;
       -- SPEC_QUESTION, INST_QUESTION: The RM instantiation does not enforce
       -- this type, it accepts any data. Does this need to be specified?
-      appData : Set AppDataElement
+      appData : Set AppDataElement;
     };
 
   positive
@@ -168,7 +195,7 @@ module Resource;
       consumed : Set Resource;
       -- The value of customInputs is an anomaEncoded (jammed) value of some
       -- application specific data type.
-      customInputs : Nock.Atom
+      customInputs : Nock.Atom;
     };
 
   --- Compute a proof for a resource logic
@@ -198,7 +225,16 @@ module Resource;
 end;
 
 -- Add the Resource type and constructor to the scope for convenience.
-open Resource using {Resource; mkResource; ResourceLogic; PublicInputs; module PublicInputs; mkPublicInputs; PrivateInputs; module PrivateInputs; mkPrivateInputs} public;
+open Resource using {
+  Resource;
+  mkResource;
+  PublicInputs;
+  module PublicInputs;
+  mkPublicInputs;
+  PrivateInputs;
+  module PrivateInputs;
+  mkPrivateInputs;
+} public;
 
 --- A module containing data types and functions related to transactions.
 --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/transaction.md?plain=1#L8
@@ -213,7 +249,7 @@ module Transaction;
       --- The delta associated with the transaction.
       delta : Delta;
       --- The transaction balance proof.
-      balanceProof : Proof
+      balanceProof : Proof;
     };
 
   -- Add the Transaction projection functions to the scope for convenience.
@@ -228,3 +264,45 @@ end;
 
 -- Add the Transaction type and constructor to the scope for convenience.
 open Transaction using {Transaction; mkTransaction} public;
+
+module Traits;
+  import Anoma.Builtin.System open using {anomaEncode};
+  import Stdlib.Trait.Ord.Eq open using {fromOrdToEq};
+
+  instance
+  ordByteArrayI : Ord Nock.ByteArray :=
+    let
+      prod (b : Nock.ByteArray) : _ :=
+        Nock.ByteArray.length b, Nock.ByteArray.payload b;
+    in mkOrd@{
+         cmp (lhs rhs : Nock.ByteArray) : Ordering :=
+           Ord.cmp (prod lhs) (prod rhs);
+       };
+
+  --- Define an Ord instance via anomaEncode.
+  anomaEncodeOrd {A} : Ord A := mkOrd (Ord.cmp on anomaEncode);
+
+  instance
+  ordCommitmentI : Ord Commitment := anomaEncodeOrd;
+
+  instance
+  eqCommitmentI : Eq Commitment := fromOrdToEq;
+
+  instance
+  ordNullifierI : Ord Nullifier := anomaEncodeOrd;
+
+  instance
+  eqNullifierI : Eq Nullifier := fromOrdToEq;
+
+  instance
+  ordLogicI : Ord Resource.Logic := anomaEncodeOrd;
+
+  instance
+  eqLogicI : Eq Resource.Logic := fromOrdToEq;
+
+  instance
+  ordKindI : Ord Kind := anomaEncodeOrd;
+
+  instance
+  eqKindI : Eq Kind := fromOrdToEq;
+end;

--- a/Anoma/Base.juvix
+++ b/Anoma/Base.juvix
@@ -65,10 +65,6 @@ module Opaque;
   --- The zero value of `Opaque.Delta`.
   -- This is not in the specification but is used to initialize delta fields.
   axiom zeroDelta : Delta;
-
-  -- TODO: Other Set functions will be required.
-  -- See https://github.com/anoma/nspec/issues/197
-  axiom Set : Type -> Type;
 end;
 
 -- Add opaque types to the scope for convenience.

--- a/Anoma/Base.juvix
+++ b/Anoma/Base.juvix
@@ -1,0 +1,251 @@
+{-- This module contains the _base interface_ for the Anoma Resource Machine.
+
+The _base interface_ describes the interface exposed by the transparent
+instantiation of the RM specification.
+
+A higher-level interace that is transformed to this base interface will be
+provided to Application developers.
+
+The base interface does not include the standard library functions (signing,
+encoding, hashing) that application developers will require to develop
+applications.
+
+In what follows _RM instantiation_ refers to the Elixir transparent RM instantiation.
+
+Axioms are used for functions that are provided by the RM instantiation.
+
+Links to the RM specification are provided for each data type field and function.
+
+Questions about the RM specification are marked with 'SPEC_QUESTION'.
+Questions about the RM instantiation are marked with 'INST_QUESTION'.
+
+https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/index.md --}
+module Anoma.Base;
+
+import Stdlib.Prelude open;
+
+--- A module containing types that are currently unknown or require furhter discussion.
+-- SPEC_QUESTION / INST_QUESTION: What should these types be?
+module Unknown;
+  -- This is currently equal to the function type in RM instantiation.
+  axiom ResourceLogicFieldType : Type;
+
+  -- This is currently Nock.Atom in the RM instantiation.
+  axiom ResourceLabelFieldType : Type;
+
+  -- This is currently Nock.ByteArray in the RM instantiation.
+  axiom ResourceValueFieldType : Type;
+end;
+
+--- A module containing Nock types used in the interface.
+---
+--- Stanard Juvix types (e.g Bool and Nat) are used in the interface where the
+--- semantics of the Juvix type and the Nock type are the same (e.g a boolean flag).
+module Nock;
+  --- A type representing a Nock atom.
+  type Atom := mkAtom Nat;
+
+  --- The Nock encoding of a ByteArray.
+  type ByteArray :=
+    mkByteArray@{
+      --- The number of bytes in the ByteArray.
+      length : Atom;
+      --- The bytes of the ByteArray represented as an ;Atom; in little-endian byte ordering.
+      payload : Atom
+    };
+end;
+
+--- A module containing opaque types whose values can only be constructed using
+--- RM instantiation functions and values provided by the RM instantiation.
+---
+--- INST_QUESTION: Can we assume that Kind, Commitment, Proof and
+--- Delta types etc. are ;Nock.Atom;s so we don't need to make them builtin axioms?
+module Opaque;
+  axiom Kind : Type;
+
+  -- We need access to the underlying atom for Commitment and Nullifier to
+  -- construct a public input tag.
+  type Commitment := private-mkCommitment Nock.Atom;
+
+  type Nullifier := private-mkNullifier Nock.Atom;
+
+  axiom Delta : Type;
+
+  axiom Proof : Type;
+
+  axiom CommitmentTreeRoot : Type;
+
+  --- The zero value of `Opaque.Delta`.
+  -- This is not in the specification but is used to initialize delta fields.
+  axiom zeroDelta : Delta;
+
+  -- TODO: Other Set functions will be required.
+  -- See https://github.com/anoma/nspec/issues/197
+  axiom Set : Type -> Type;
+end;
+
+-- Add opaque types to the scope for convenience.
+open Opaque public;
+
+--- A module containing data types and functions related to resources.
+--- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/resource/definition.md
+module Resource;
+
+  type Resource :=
+    mkResource@{
+      --- A 'succinct' representation of the resource logic.
+      logic : Unknown.ResourceLogicFieldType;
+      --- Specifies the fungibility domain for the resource.
+      label : Unknown.ResourceLabelFieldType;
+      --- A number representing the quentity of the resource.
+      quantity : Nat;
+      --- The fungible data associated with the resource.
+      value : Unknown.ResourceValueFieldType;
+      --- A flag that reflects the resource's ephemerality.
+      isEphemeral : Bool;
+      --- Guarantees the uniqueness of the resource computable components.
+      nonce : Nock.Atom;
+      --- Nullifier key commitment
+      nullifierKeyCommitment : Nock.Atom;
+      --- Randomness seed
+      rseed : Nock.Atom
+    };
+
+  -- Add the Resource projection functions into scope for convenience.
+  open Resource public;
+
+  --- Compute a commitment to a ;Resource;
+  --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/resource/computable_components/commitment.md?plain=1#L8
+  axiom commitment : Resource -> Commitment;
+
+  --- Compute the kind of a ;Resource;
+  --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/resource/computable_components/kind.md?plain=1#L9
+  axiom kind : Resource -> Kind;
+
+  --- Compute the nullifier of a ;Resource;
+  --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/resource/computable_components/nullifier.md?plain=1#L8
+  axiom nullifier : Resource -> Nullifier;
+
+  --- Compute the delta of a ;Resource;
+  --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/resource/computable_components/delta.md?plain=1#L8
+  axiom delta : Resource -> Delta;
+
+end;
+
+-- Add the Resource type and constructor to the scope for convenience.
+open Resource using {Resource; mkResource} public;
+
+--- A module containing data types and functions related to actions.
+--- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/action.md
+module Action;
+
+  type AppDataValue :=
+    mkAppDataValue@{
+      value : Nock.Atom;
+      -- SPEC_QUESTION: Is the deletion criterion required?
+      deletionCriterion : Nock.Atom
+    };
+
+  type AppDataElement :=
+    mkAppDataElement@{
+      key : Nock.Atom;
+      value : AppDataValue
+    };
+
+  type Action :=
+    mkAction@{
+      --- A set of created resources commitments.
+      commitments : Set Commitment;
+      --- A set of consumed resources nullifiers.
+      nullifiers : Set Nullifier;
+      --- A set of proofs.
+      -- INST_QUESTION: How do you / do you need to distinguish between the different types of proofs?
+      proofs : Set Proof;
+      --- Application specific data needed to create resource logic proofs.
+      -- SPEC_QUESTION, INST_QUESTION: The RM instantiation does not enforce
+      -- this type, it accepts any data. Does this need to be specified?
+      appData : Set AppDataElement
+    };
+
+  -- Add the Action and AppData projection functions to the scope for convenience.
+  open Action public;
+
+  --- Compute the delta for an action.
+  --- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/action.md?plain=1#L79
+  axiom delta : Action -> Delta;
+
+  --- Compute a compliance proof for the Action.
+  axiom prove : Action -> Proof;
+
+end;
+
+-- Add the Action types and constructors to the scope for convenience.
+open Action using {Action; mkAction; AppDataElement; module AppDataElement; mkAppDataElement; AppDataValue; module AppDataValue; mkAppDataValue} public;
+
+--- A module containing types related to the resource logic.
+--- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/function_formats/resource_logic.md?plain=1#L8
+module ResourceLogic;
+
+  type PublicInputs :=
+    mkPublicInputs@{
+      commitments : Set Commitment;
+      nullifiers : Set Nullifier;
+      -- In the RM instantiation tag is equal to exactly one commitment or
+      -- nullifier.
+      tag : Nock.Atom;
+      -- SPEC_QUESTION, INST_QUESTION: The RM instantiation does not enforce
+      -- this type, it accepts any data. Does this need to be specified?
+      appData : Set AppDataElement
+    };
+
+  type PrivateInputs :=
+    mkPrivateInputs@{
+      created : Set Resource;
+      consumed : Set Resource;
+      -- The value of customInputs is an anomaEncoded (jammed) value of some
+      -- application specific data type.
+      customInputs : Nock.Atom
+    };
+
+  --- The type of a resource logic.
+  -- SPEC_QUESTION: Is this a valid signature for a resource logic function?
+  ResourceLogic : Type := PublicInputs -> PrivateInputs -> Bool;
+
+  --- Compute a proof for a resource logic
+  -- SPEC_QUESTION: Is this a valid signature for computing a proof of a
+  -- transparent resource logic function?
+  axiom prove : Resource -> PublicInputs -> PrivateInputs -> Proof;
+
+end;
+
+-- Add the ResourceLogic, PublicInputs, and PrivateInputs types to the scope for convenience.
+open ResourceLogic using {ResourceLogic; PublicInputs; module PublicInputs; PrivateInputs; module PrivateInputs};
+
+--- A module containing data types and functions related to transactions.
+--- https://github.com/anoma/nspec/blob/920678dc0cb41e7959a42171c63f515f0377aa51/docs/system_architecture/state/resource_machine/transaction.md?plain=1#L8
+module Transaction;
+  type Transaction :=
+    mkTransaction@{
+      --- A set of roots of the commitment tree.
+      -- SPEC_QUESTION, INST_QUESTION: How do we obtain these roots?
+      roots : Set CommitmentTreeRoot;
+      --- A set of actions.
+      actions : Set Action;
+      --- The delta associated with the transaction.
+      delta : Delta;
+      --- The transaction balance proof.
+      balanceProof : Proof
+    };
+
+  -- Add the Transaction projection functions to the scope for convenience.
+  open Transaction public;
+
+  --- Compute the delta for a list of actions.
+  axiom actionsDelta : List Action -> Delta;
+
+  --- Compute a proof for the transaction balance.
+  axiom proveBalance : Transaction -> Proof;
+end;
+
+-- Add the Transaction type and constructor to the scope for convenience.
+open Transaction using {Transaction; mkTransaction} public;

--- a/Anoma/Base/Set.juvix
+++ b/Anoma/Base/Set.juvix
@@ -1,5 +1,9 @@
 {-- This module contains the Set API to be used when interacting with Anoma.
 
+The Set type from `Stdlib.Data.Set` should be used in applications. The
+functions in this module should be used to translate to and from the Anoma Set
+data structure.
+
 It is recommended that you import this module as follows:
 
 import Anoma.Base.Set as Set open using {Set}
@@ -12,136 +16,34 @@ if you use this module and the standard library set from Stdlib.Data.Set in the
 same module. --}
 module Anoma.Base.Set;
 
-import Stdlib.Prelude open hiding {foldl; all; any; isMember; for};
+import Stdlib.Prelude open;
 import Stdlib.Data.Set as StdlibSet open using {Set as StdlibSet};
 
 --- A module containing the builtin Anoma Set API.
 module Internal;
-
   axiom Set : Type -> Type;
 
-  axiom lookup : {A : Type} -> (elem : A) -> (set : Set A) -> Maybe A;
-
-  axiom isMember : {A : Type} -> (elem : A) -> (set : Set A) -> Bool;
-
-  axiom insert : {A : Type} -> (elem : A) -> (set : Set A) -> Set A;
-
+  -- Uses Hoon stdlib ++tap:in https://developers.urbit.org/reference/hoon/stdlib/2h#tapin
   axiom toList : {A : Type} -> (set : Set A) -> List A;
 
+  -- Uses Hoon stdlib ++silt https://developers.urbit.org/reference/hoon/stdlib/2l#silt
   axiom fromList : {A : Type} -> (list : List A) -> Set A;
-
-  axiom size : {A : Type} -> (set : Set A) -> Nat;
-
-  axiom delete : {A : Type} -> (elem : A) -> (set : Set A) -> Set A;
-
-  axiom map : {A B : Type} -> (fun : A -> B) -> (set : Set A) -> Set B;
-
-  --- Implemented using `++rep:in` https://developers.urbit.org/reference/hoon/stdlib/2h#repin
-  -- NB: The initial accumulator should be the second default argument of the function.
-  axiom foldl : {A B : Type} -> (fun : B -> A -> B) -> (acc : B) -> Set A -> B;
-
-  axiom union : {A : Type} -> (set1 set2 : Set A) -> Set A;
-
-  axiom intersection : {A : Type} -> (set1 set2 : Set A) -> Set A;
-
-  axiom difference : {A : Type} -> (set1 set2 : Set A) -> Set A;
-
-  axiom all : {A : Type} -> (predicate : A -> Bool) -> (set : Set A) -> Bool;
-
-  axiom any : {A : Type} -> (predicate : A -> Bool) -> (set : Set A) -> Bool;
 end;
 
 open Internal using {Set} public;
 
-{-# inline: true #-}
-singleton {A} (elem : A) : Set A := Internal.fromList {A} [elem];
-
-{-# inline: true #-}
-empty {A} : Set A := Internal.fromList {A} [];
-
-{-# inline: true #-}
-lookup {A} (elem : A) (set : Set A) : Maybe A := Internal.lookup {A} elem set;
-
-{-# inline: true #-}
-isMember {A} (elem : A) (set : Set A) : Bool := Internal.isMember {A} elem set;
-
-{-# inline: true #-}
-insert {A} (elem : A) (set : Set A) : Set A := Internal.insert {A} elem set;
-
+--- Returns the elements of `set` as a ;List; in an unspecified order.
 {-# inline: true #-}
 toList {A} (set : Set A) : List A := Internal.toList {A} set;
 
+--- Create a set from an unsorted ;List;.
 {-# inline: true #-}
 fromList {A} (list : List A) : Set A := Internal.fromList {A} list;
 
+--- Convert a Juvix Stdlib Set to an Anoma Set.
 fromStdlibSet {A} (set : StdlibSet A) : Set A :=
   set |> StdlibSet.toList |> fromList;
 
+--- Convert an Anoma Set to a Juvix Stdlib Set.
 toStdlibSet {A} {{Ord A}} (set : Set A) : StdlibSet A :=
   set |> toList |> StdlibSet.fromList;
-
-{-# inline: true #-}
-size {A} (set : Set A) : Nat := Internal.size {A} set;
-
-{-# inline: true #-}
-delete {A} (elem : A) (set : Set A) : Set A := Internal.delete elem set;
-
-{-# inline: true #-}
-union {A} (set1 set2 : Set A) : Set A := Internal.union {A} set1 set2;
-
-{-# inline: true #-}
-intersection {A} (set1 set2 : Set A) : Set A := Internal.intersection set1 set2;
-
-{-# inline: true #-}
-difference {A} (set1 set2 : Set A) : Set A := Internal.difference set1 set2;
-
-{-# inline: true #-}
-isEmpty {A} (set : Set A) : Bool := size set == 0;
-
-syntax iterator map {init := 0; range := 1};
-{-# inline: true #-}
-map {A B} (fun : A -> B) (set : Set A) : Set B := Internal.map {A} {B} fun set;
-
-{-# inline: true #-}
-foldl {A B} (fun : B -> A -> B) (acc : B) (set : Set A) : B :=
-  Internal.foldl {A} {B} fun acc set;
-
--- The hoon stdlib does not define foldr so we cannot implement Foldable.
-syntax iterator for {init := 1; range := 1};
-{-# inline: true #-}
-for : {A B : Type} -> (B -> A -> B) -> B -> Set A -> B := foldl;
-
-syntax iterator all {init := 0; range := 1};
-{-# inline: true #-}
-all {A} (predicate : A -> Bool) (set : Set A) : Bool :=
-  Internal.all {A} predicate set;
-
-syntax iterator any {init := 0; range := 1};
-{-# inline: true #-}
-any {A} (predicate : A -> Bool) (set : Set A) : Bool :=
-  Internal.any {A} predicate set;
-
-isSubset {A} (set1 set2 : Set A) : Bool :=
-  all (x in set1) {
-    isMember x set2
-  };
-
-syntax iterator filter {init := 0; range := 1};
-{-# specialize: [1] #-}
-filter {A} (predicate : A -> Bool) (set : Set A) : Set A :=
-  for (acc := empty) (x in set) {
-    if
-      | predicate x := insert x acc
-      | else := acc
-  };
-
-{-# specialize: [1] #-}
-disjointUnion {A} (set1 set2 : Set A) : Result A (Set A) :=
-  for (acc := ok set2) (x in set1) {
-    case acc of
-      | error _ := acc
-      | ok set :=
-        if
-          | isMember x set2 := error x
-          | else := ok (insert x set)
-  };

--- a/Anoma/Base/Set.juvix
+++ b/Anoma/Base/Set.juvix
@@ -1,0 +1,147 @@
+{-- This module contains the Set API to be used when interacting with Anoma.
+
+It is recommended that you import this module as follows:
+
+import Anoma.Base.Set as Set open using {Set}
+
+or
+
+import Anoma.Base.Set as AnomaSet open using {Set as AnomaSet}
+
+if you use this module and the standard library set from Stdlib.Data.Set in the
+same module. --}
+module Anoma.Base.Set;
+
+import Stdlib.Prelude open hiding {foldl; all; any; isMember; for};
+import Stdlib.Data.Set as StdlibSet open using {Set as StdlibSet};
+
+--- A module containing the builtin Anoma Set API.
+module Internal;
+
+  axiom Set : Type -> Type;
+
+  axiom lookup : {A : Type} -> (elem : A) -> (set : Set A) -> Maybe A;
+
+  axiom isMember : {A : Type} -> (elem : A) -> (set : Set A) -> Bool;
+
+  axiom insert : {A : Type} -> (elem : A) -> (set : Set A) -> Set A;
+
+  axiom toList : {A : Type} -> (set : Set A) -> List A;
+
+  axiom fromList : {A : Type} -> (list : List A) -> Set A;
+
+  axiom size : {A : Type} -> (set : Set A) -> Nat;
+
+  axiom delete : {A : Type} -> (elem : A) -> (set : Set A) -> Set A;
+
+  axiom map : {A B : Type} -> (fun : A -> B) -> (set : Set A) -> Set B;
+
+  --- Implemented using `++rep:in` https://developers.urbit.org/reference/hoon/stdlib/2h#repin
+  -- NB: The initial accumulator should be the second default argument of the function.
+  axiom foldl : {A B : Type} -> (fun : B -> A -> B) -> (acc : B) -> Set A -> B;
+
+  axiom union : {A : Type} -> (set1 set2 : Set A) -> Set A;
+
+  axiom intersection : {A : Type} -> (set1 set2 : Set A) -> Set A;
+
+  axiom difference : {A : Type} -> (set1 set2 : Set A) -> Set A;
+
+  axiom all : {A : Type} -> (predicate : A -> Bool) -> (set : Set A) -> Bool;
+
+  axiom any : {A : Type} -> (predicate : A -> Bool) -> (set : Set A) -> Bool;
+end;
+
+open Internal using {Set} public;
+
+{-# inline: true #-}
+singleton {A} (elem : A) : Set A := Internal.fromList {A} [elem];
+
+{-# inline: true #-}
+empty {A} : Set A := Internal.fromList {A} [];
+
+{-# inline: true #-}
+lookup {A} (elem : A) (set : Set A) : Maybe A := Internal.lookup {A} elem set;
+
+{-# inline: true #-}
+isMember {A} (elem : A) (set : Set A) : Bool := Internal.isMember {A} elem set;
+
+{-# inline: true #-}
+insert {A} (elem : A) (set : Set A) : Set A := Internal.insert {A} elem set;
+
+{-# inline: true #-}
+toList {A} (set : Set A) : List A := Internal.toList {A} set;
+
+{-# inline: true #-}
+fromList {A} (list : List A) : Set A := Internal.fromList {A} list;
+
+fromStdlibSet {A} (set : StdlibSet A) : Set A :=
+  set |> StdlibSet.toList |> fromList;
+
+toStdlibSet {A} {{Ord A}} (set : Set A) : StdlibSet A :=
+  set |> toList |> StdlibSet.fromList;
+
+{-# inline: true #-}
+size {A} (set : Set A) : Nat := Internal.size {A} set;
+
+{-# inline: true #-}
+delete {A} (elem : A) (set : Set A) : Set A := Internal.delete elem set;
+
+{-# inline: true #-}
+union {A} (set1 set2 : Set A) : Set A := Internal.union {A} set1 set2;
+
+{-# inline: true #-}
+intersection {A} (set1 set2 : Set A) : Set A := Internal.intersection set1 set2;
+
+{-# inline: true #-}
+difference {A} (set1 set2 : Set A) : Set A := Internal.difference set1 set2;
+
+{-# inline: true #-}
+isEmpty {A} (set : Set A) : Bool := size set == 0;
+
+syntax iterator map {init := 0; range := 1};
+{-# inline: true #-}
+map {A B} (fun : A -> B) (set : Set A) : Set B := Internal.map {A} {B} fun set;
+
+{-# inline: true #-}
+foldl {A B} (fun : B -> A -> B) (acc : B) (set : Set A) : B :=
+  Internal.foldl {A} {B} fun acc set;
+
+-- The hoon stdlib does not define foldr so we cannot implement Foldable.
+syntax iterator for {init := 1; range := 1};
+{-# inline: true #-}
+for : {A B : Type} -> (B -> A -> B) -> B -> Set A -> B := foldl;
+
+syntax iterator all {init := 0; range := 1};
+{-# inline: true #-}
+all {A} (predicate : A -> Bool) (set : Set A) : Bool :=
+  Internal.all {A} predicate set;
+
+syntax iterator any {init := 0; range := 1};
+{-# inline: true #-}
+any {A} (predicate : A -> Bool) (set : Set A) : Bool :=
+  Internal.any {A} predicate set;
+
+isSubset {A} (set1 set2 : Set A) : Bool :=
+  all (x in set1) {
+    isMember x set2
+  };
+
+syntax iterator filter {init := 0; range := 1};
+{-# specialize: [1] #-}
+filter {A} (predicate : A -> Bool) (set : Set A) : Set A :=
+  for (acc := empty) (x in set) {
+    if
+      | predicate x := insert x acc
+      | else := acc
+  };
+
+{-# specialize: [1] #-}
+disjointUnion {A} (set1 set2 : Set A) : Result A (Set A) :=
+  for (acc := ok set2) (x in set1) {
+    case acc of
+      | error _ := acc
+      | ok set :=
+        if
+          | isMember x set2 := error x
+          | else := ok (insert x set)
+  };

--- a/Anoma/Builtin/ByteArray.juvix
+++ b/Anoma/Builtin/ByteArray.juvix
@@ -1,0 +1,33 @@
+module Anoma.Builtin.ByteArray;
+
+import Stdlib.Prelude open;
+import Stdlib.Trait.Ord.Eq open using {fromOrdToEq};
+
+builtin bytearray
+axiom ByteArray : Type;
+
+builtin bytearray-from-list-byte
+axiom mkByteArray : List Byte -> ByteArray;
+
+builtin bytearray-length
+axiom length : ByteArray -> Nat;
+
+-- TODO: Everything below needs to be removed.
+syntax alias AnomaContents := Nat;
+
+builtin anoma-bytearray-to-anoma-contents
+axiom toAnomaContents : ByteArray -> AnomaContents;
+
+builtin anoma-bytearray-from-anoma-contents
+axiom fromAnomaContents : Nat -> AnomaContents -> ByteArray;
+
+--- Implements the ;Ord; trait for ;ByteArray;.
+instance
+ByteArray-Ord : Ord ByteArray :=
+  mkOrd@{
+    cmp := Ord.cmp on toAnomaContents;
+  };
+
+--- Implements the ;Eq; trait for ;ByteArray;.
+instance
+ByteArray-Eq : Eq ByteArray := fromOrdToEq;

--- a/Anoma/Builtin/System.juvix
+++ b/Anoma/Builtin/System.juvix
@@ -1,0 +1,82 @@
+module Anoma.Builtin.System;
+
+import Stdlib.Prelude open;
+import Anoma.Builtin.ByteArray open;
+
+module Internal;
+  syntax alias PublicKey := ByteArray;
+  syntax alias PrivateKey := ByteArray;
+
+  syntax alias Signature := ByteArray;
+  syntax alias SignedMessage := ByteArray;
+end;
+
+-- TODO Add builtin.
+-- builtin anoma-opaque
+-- axiom AnomaOpaque : Type;
+-- In the backend this can be any noun.
+axiom AnomaOpaque : Type;
+
+--- Encodes a value into a natural number.
+builtin anoma-encode
+axiom anomaEncode : {Value : Type}
+  -- | The value to encode.
+  -> Value
+  -- | The encoded natural number.
+  -> Nat;
+
+--- Decodes a value from a natural number.
+builtin anoma-decode
+axiom anomaDecode : {Value : Type}
+  -- | The natural number to decode .
+  -> Nat
+  -- | The decoded value.
+  -> Value;
+
+--- Signs a message with a private key and returns a signed message.
+builtin anoma-sign
+axiom anomaSign : {Message : Type}
+  -- | The message to sign.
+  -> Message
+  -- | The signing private key.
+  -> Internal.PrivateKey
+  -- | The resulting signed message.
+  -> Internal.SignedMessage;
+
+--- Signs a message with a private key and returns the signature.
+builtin anoma-sign-detached
+axiom anomaSignDetached : {Message : Type}
+  -- | The message to sign.
+  -> Message
+  -- | The signing private key.
+  -> Internal.PrivateKey
+  -- The resulting signature
+  -> Internal.Signature;
+
+--- Verifies a signature against a message and public key.
+builtin anoma-verify-detached
+axiom anomaVerifyDetached : {Message : Type}
+  -- | The signature to verify.
+  -> Internal.Signature
+  -- | The message to verify against.
+  -> Message
+  -- | The signer public key to verify against.
+  -> Internal.PublicKey
+  -- | The verification result.
+  -> Bool;
+
+--- Verifies a signature against a message and public key and return the message on success.
+builtin anoma-verify-with-message
+axiom anomaVerifyWithMessage : {Message : Type}
+  -- | The signed message to verify.
+  -> Internal.SignedMessage
+  -- | The signer public key to verify against.
+  -> Internal.PublicKey
+  -- | The original message.
+  -> Maybe Message;
+
+instance
+AnomaOpaque-Ord : Ord AnomaOpaque :=
+  mkOrd@{
+    cmp := Ord.cmp on anomaEncode;
+  };

--- a/Anoma/Resource/Types.juvix
+++ b/Anoma/Resource/Types.juvix
@@ -3,48 +3,49 @@ module Anoma.Resource.Types;
 import Stdlib.Prelude open;
 import Stdlib.Trait.Ord.Eq open using {fromOrdToEq};
 import Anoma.Utils open;
+import Anoma.Base as Base;
 
 --- A fixed-size data type encoding the reference to the resource logic function.
 --- NOTE: For the private testnet, the requirement can be relaxed by allowing ;LogicRef; to be dynamically-sized.
-type LogicRef := mkLogicRef@{unLogicRef : MISSING_DEFINITION};
+type LogicRef := mkLogicRef@{unLogicRef : Base.Resource.Logic};
 
 --- A fixed-size data type encoding the reference to the resource label field.
 --- NOTE: For the private testnet, the requirement can be relaxed by allowing ;LabelRef; to be dynamically-sized.
-type LabelRef := mkLabelRef@{unLabelRef : MISSING_DEFINITION};
+type LabelRef := mkLabelRef@{unLabelRef : Base.Resource.Label};
 
 --- A fixed-size data type encoding the reference to the resource value field.
 --- NOTE: For the private testnet, the requirement can be relaxed by allowing ;ValueRef; to be dynamically-sized.
-type ValueRef := mkValueRef@{unValueRef : MISSING_DEFINITION};
+type ValueRef := mkValueRef@{unValueRef : Base.Resource.Value};
 
 --- A fixed-size data type encoding the quantity of a resource.
-type Quantity := mkQuantity@{unQuantity : MISSING_DEFINITION};
+type Quantity := mkQuantity@{unQuantity : Base.Resource.Quantity};
 
 --- A fixed-size data type encoding the public commitment to the private nullifier key.
 type NullifierKeyCommitment :=
-  mkNullifierKeyCommitment@{unNullifierKeyCommitment : MISSING_DEFINITION};
+  mkNullifierKeyCommitment@{unNullifierKeyCommitment : Base.Resource.NullifierKeyCommitment};
 
 --- A fixed-size data type encoding a number to be used once ensuring that the resource commitment is unique.
 --- NOTE: This should be a number having an at most negligible chance of repeating is sufficient, e.g., a pseudo-random number.
-type Nonce := mkNonce@{unNonce : MISSING_DEFINITION};
+type Nonce := mkNonce@{unNonce : Base.Resource.Nonce};
 
 --- A fixed-size data type encoding a randomness seed.
 --- NOTE: This seed provides pseudo randomness and cannot be expected to provide true randomness.
-type RandSeed := mkRandSeed@{unRandSeed : MISSING_DEFINITION};
+type RandSeed := mkRandSeed@{unRandSeed : Base.Resource.RSeed};
 
 --- The resource label type.
-type Label := mkLabel@{unLabel : MISSING_DEFINITION};
+type Label := mkLabel@{unLabel : Base.Resource.Label};
 
 --- The resource value type.
-type Value := mkValue@{unValue : MISSING_DEFINITION};
+type Value := mkValue@{unValue : Base.Resource.Value};
 
 --- The resource kind type.
-type Kind := mkKind@{unKind : MISSING_DEFINITION};
+type Kind := mkKind@{unKind : Base.Kind};
 
 --- The resource commitment type.
-type Commitment := mkCommitment@{unCommitment : MISSING_DEFINITION};
+type Commitment := mkCommitment@{unCommitment : Base.Commitment};
 
 --- The resource nullifier type.
-type Nullifier := mkNullifier@{unNullifier : MISSING_DEFINITION};
+type Nullifier := mkNullifier@{unNullifier : Base.Nullifier};
 
 --- The nullifier key type describing a secret required to compute the ;Nullifier; of a resource
 type NullifierKey := mkNullifierKey@{unNullifierKey : MISSING_DEFINITION};


### PR DESCRIPTION
The aim of this PR is to add a low-level Anoma interface which matches the structure of data that must be sent to the node. 

The API that application developers use is called the 'high-level' interface. This PR will add a translation layer from the high-level to the low-level interface. The high-level interface can have use richer types and include facilities to improve the developer UX.